### PR TITLE
SNOW-1371694 Expose correlation id during sync

### DIFF
--- a/base/src/com/google/idea/blaze/base/sync/BuildPhaseSyncTask.java
+++ b/base/src/com/google/idea/blaze/base/sync/BuildPhaseSyncTask.java
@@ -19,6 +19,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.idea.blaze.base.issueparser.BlazeIssueParser.targetDetectionQueryParsers;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -74,7 +75,9 @@ import com.intellij.openapi.util.text.StringUtil;
 import java.io.File;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 
 /** Runs the 'blaze build' phase of sync. */
@@ -444,6 +447,13 @@ public final class BuildPhaseSyncTask {
           // We don't want blaze build errors to fail the whole sync
           context.setPropagatesErrors(false);
 
+          // Snoflake specific: we pass an extra variable RECORD_INVOCATION_CORRELATION_ID 
+          // in order to group the builds from all shards as a single invocation in the
+          // metrics.
+          Map<String, String> correlationEnvVar = ImmutableMap.of(
+            "RECORD_INVOCATION_CORRELATION_ID",
+            UUID.randomUUID().toString());
+
           BlazeIdeInterface blazeIdeInterface = BlazeIdeInterface.getInstance();
           return blazeIdeInterface.build(
               project,
@@ -456,7 +466,8 @@ public final class BuildPhaseSyncTask {
               projectState.getLanguageSettings(),
               ImmutableSet.of(OutputGroup.RESOLVE, OutputGroup.INFO),
               BlazeInvocationContext.SYNC_CONTEXT,
-              invokeParallel);
+              invokeParallel,
+              correlationEnvVar);
         });
   }
 }

--- a/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterface.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterface.java
@@ -15,6 +15,7 @@
  */
 package com.google.idea.blaze.base.sync.aspects;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.idea.blaze.base.bazel.BuildSystem.BuildInvoker;
 import com.google.idea.blaze.base.command.BlazeInvocationContext;
@@ -31,6 +32,7 @@ import com.google.idea.blaze.base.sync.projectview.WorkspaceLanguageSettings;
 import com.google.idea.blaze.base.sync.sharding.ShardedTargetList;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.project.Project;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 /** A blaze build interface used for mocking out the blaze layer in tests. */
@@ -72,4 +74,37 @@ public interface BlazeIdeInterface {
       ImmutableSet<OutputGroup> outputGroups,
       BlazeInvocationContext blazeInvocationContext,
       boolean invokeParallel);
+
+  /**
+   * Invokes a blaze build for the given output groups
+   * running Bazel with the provided environment variables.
+   *
+   * @param outputGroups Set of {@link OutputGroup} to be generated in the build.
+   */
+  default BlazeBuildOutputs build(
+      Project project,
+      BlazeContext context,
+      WorkspaceRoot workspaceRoot,
+      BlazeVersionData blazeVersion,
+      BuildInvoker invoker,
+      ProjectViewSet projectViewSet,
+      ShardedTargetList shardedTargets,
+      WorkspaceLanguageSettings workspaceLanguageSettings,
+      ImmutableSet<OutputGroup> outputGroups,
+      BlazeInvocationContext blazeInvocationContext,
+      boolean invokeParallel,
+      Map<String, String> envVars) {
+    return build(
+        project,
+        context,
+        workspaceRoot,
+        blazeVersion,
+        invoker,
+        projectViewSet,
+        shardedTargets,
+        workspaceLanguageSettings,
+        outputGroups,
+        blazeInvocationContext,
+        invokeParallel);
+    }
 }

--- a/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
@@ -586,6 +586,35 @@ public class BlazeIdeInterfaceAspectsImpl implements BlazeIdeInterface {
       ImmutableSet<OutputGroup> outputGroups,
       BlazeInvocationContext blazeInvocationContext,
       boolean invokeParallel) {
+    return build(
+        project,
+        context,
+        workspaceRoot,
+        blazeVersion,
+        invoker,
+        projectViewSet,
+        shardedTargets,
+        workspaceLanguageSettings,
+        outputGroups,
+        blazeInvocationContext,
+        invokeParallel,
+        ImmutableMap.of());
+  }
+
+  @Override
+  public BlazeBuildOutputs build(
+      Project project,
+      BlazeContext context,
+      WorkspaceRoot workspaceRoot,
+      BlazeVersionData blazeVersion,
+      BuildInvoker invoker,
+      ProjectViewSet projectViewSet,
+      ShardedTargetList shardedTargets,
+      WorkspaceLanguageSettings workspaceLanguageSettings,
+      ImmutableSet<OutputGroup> outputGroups,
+      BlazeInvocationContext blazeInvocationContext,
+      boolean invokeParallel,
+      Map<String, String> envVars) {
     AspectStrategy aspectStrategy = AspectStrategy.getInstance(blazeVersion);
 
     final Ref<BlazeBuildOutputs> combinedResult = new Ref<>();
@@ -648,7 +677,8 @@ public class BlazeIdeInterfaceAspectsImpl implements BlazeIdeInterface {
                             aspectStrategy,
                             outputGroups,
                             additionalBlazeFlags,
-                            invokeParallel);
+                            invokeParallel,
+                            envVars);
                     if (result.buildResult.outOfMemory()) {
                       logger.warn(
                           String.format(
@@ -734,7 +764,8 @@ public class BlazeIdeInterfaceAspectsImpl implements BlazeIdeInterface {
       AspectStrategy aspectStrategy,
       ImmutableSet<OutputGroup> outputGroups,
       List<String> additionalBlazeFlags,
-      boolean invokeParallel)
+      boolean invokeParallel,
+      Map<String, String> envVars)
       throws BuildException {
 
     boolean onlyDirectDeps =
@@ -762,7 +793,7 @@ public class BlazeIdeInterfaceAspectsImpl implements BlazeIdeInterface {
       aspectStrategy.addAspectAndOutputGroups(
           builder, outputGroups, activeLanguages, onlyDirectDeps);
 
-      return invoker.getCommandRunner().run(project, builder, buildResultHelper, context, ImmutableMap.of());
+      return invoker.getCommandRunner().run(project, builder, buildResultHelper, context, envVars);
     }
   }
 }


### PR DESCRIPTION
Description

JIRA: SNOW-1371694

Executes all bazel build shards from the same sync invocation providing an unique invocation id in order to group all shards under the same invocation in the metrics.

There is [SyncListener](https://github.com/bazelbuild/intellij/blob/master/base/src/com/google/idea/blaze/base/sync/SyncListener.java) interface that allows to add hooks before an after the sync which would make this implementation less intrusive. However, exposing an environment variable from the java process is not really straightforward and dumping the correlation id into a file would mean we need to garbage collect and worry about synchronization issues, so I ended modifying the plugin code directly,

Testing

# Checklist

- [ ] I have filed an issue about this change and discussed potential changes with the maintainers.
- [ ] I have received the approval from the maintainers to make this change.
- [ ] This is not a stylistic, refactoring, or cleanup change.

Please note that the maintainers will not be reviewing this change until all checkboxes are ticked. See 
the [Contributions](https://github.com/bazelbuild/intellij#contributions) section in the README for more 
details.

# Discussion thread for this change

Issue number: `<please reference the issue number or url here>`

# Description of this change

